### PR TITLE
Revamp iteration protocol

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,13 @@ version = "0.1.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-LearnBase = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
 MLDataUtils = "cc2ba9b6-d476-5e6d-8eaf-a92d5412d41d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+ResumableFunctions = "c5292f4c-5179-55e1-98c5-05642aab7184"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-LearnBase = "0.2.2"
 MLDataUtils = "0.5"
 julia = "1.3"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-LearnBase = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
 MLDataPattern = "9920b226-0b2a-5f5f-9153-9aa70a013f8b"
 MLDataUtils = "cc2ba9b6-d476-5e6d-8eaf-a92d5412d41d"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,11 +1,11 @@
 using Documenter, DiskDataProviders
-using DiskDataProviders, LearnBase, MLDataUtils, MLDataPattern
+using DiskDataProviders, MLDataPattern
 
 makedocs(
     sitename = "DiskDataProviders",
     # format = LaTeX(),
     format = Documenter.HTML(prettyurls = haskey(ENV, "CI")),
-    modules = [DiskDataProviders, MLDataUtils, MLDataPattern, LearnBase],
+    modules = [DiskDataProviders, MLDataPattern],
     pages = ["index.md"]
 )
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@
 # DiskDataProviders
 
 ```@setup memory
-using DiskDataProviders, Test, Serialization, MLDataUtils
+using DiskDataProviders, Test, Serialization
 ```
 
 This package implements datastructures that are iterable and backed by a buffer that is fed by data from disk. If Reading and preproccesing data is faster than one training step, it's recommended to use a [`ChannelDiskDataProvider`](@ref), if the training step is fast but reading data takes long time, [`QueueDiskDataProvider`](@ref) is recommended. Both types do the reading on a separate thread, so make sure Julia is started with at least two threads.
@@ -17,7 +17,7 @@ If the task is supervised, you may supply labels using the keyword `labels`, see
 
 ## Usage example
 ```@example memory
-using DiskDataProviders, Test, Serialization, MLDataUtils
+using DiskDataProviders, Test, Serialization
 
 # === Create some random example data ===
 dirpath = mktempdir()*"/"
@@ -80,7 +80,7 @@ All functionality in this package operates on serialized, preprocessed data file
 - [`BufferedIterator`](@ref) iterates over single datapoints from the buffer.
 - [`full_batch`](@ref) creates one enormous batch of the entire dataset.
 - For unsupervised datasets (without labels), the buffers are populated by randomly permuting the data files (shuffling). Using the default file iterator, all datapoints are visited in the same order in each epoch.
-- For supervised datasets, unique labels are cycled through and a datapoint with that label is drawn uniformly at random. 
+- For supervised datasets, unique labels are cycled through and a datapoint with that label is drawn uniformly at random.
 
 Typically, you want to use [`batchview`](@ref) for training. If you have a small enough dataset (e.g. for validation), you may want to use [`full_batch`](@ref), especially if this fits into the GPU memory. Batches are structured according to Flux's notion of a batch, e.g., the last dimension is the batch dimension.
 
@@ -90,7 +90,7 @@ Typically, you want to use [`batchview`](@ref) for training. If you have a small
 ```@index
 ```
 ```@autodocs
-Modules = [DiskDataProviders, MLDataPattern, MLDataUtils, LearnBase]
+Modules = [DiskDataProviders, MLDataPattern]
 Pages = ["DiskDataProviders.jl", "iteration.jl"]
 Private = false
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -37,7 +37,7 @@ files = dirpath .* string.(1:N) .* ".bin"
 dataset = ChannelDiskDataProvider{Vector{Float64}, Int}((T,), batch_size, queue_length; labels=labs, files=files)
 ```
 
-The dataset is iterable and can be used in loops etc. One can also create a `BatchView`, which is an iterator over batches. The batch size is defined when the DiskDataProvider is created.
+The dataset is iterable and can be used in loops etc. One can also create a [`batchview`](@ref DiskDataProviders.batchview), which is an iterator over batches. The batch size is defined when the DiskDataProvider is created.
 
 ```@repl memory
 # === Example usage of the provider ===
@@ -51,7 +51,7 @@ t = start_reading(dataset) # this function initiates the reading into the buffer
 
 wait(dataset) # Wait for the reading to start before proceeding
 
-bw = batchview(dataset);
+bw = batchview(dataset)
 
 xb,yb = first(bw) # Get the first batch from the buffer
 
@@ -75,14 +75,15 @@ All functionality in this package operates on serialized, preprocessed data file
 
 # Iterators
 - If you simply iterate over an `AbstractDiskDataProvider`, you will iterate over each datapoint in the sequence determined by the vector of file paths. This iteration is not buffered.
-- [`batchview`](@ref) creates a buffered iterator over batches.
-- [`UnbufferedIterator`](@ref) has the same behaviour as iterating over the `AbstractDiskDataProvider` (`UnbufferedIterator` is what is used under the hood).
-- [`BufferedIterator`](@ref) iterates over single datapoints from the buffer.
+- [`batchview`](@ref DiskDataProviders.batchview) creates a buffered iterator over batches.
+- [`unbuffered`](@ref) has the same behaviour as iterating over the `AbstractDiskDataProvider`.
+- [`buffered`](@ref) iterates over single datapoints from the buffer.
 - [`full_batch`](@ref) creates one enormous batch of the entire dataset.
+- [`unbuffered_batchview`](@ref) Iterates over batches, unbuffered.
 - For unsupervised datasets (without labels), the buffers are populated by randomly permuting the data files (shuffling). Using the default file iterator, all datapoints are visited in the same order in each epoch.
 - For supervised datasets, unique labels are cycled through and a datapoint with that label is drawn uniformly at random.
 
-Typically, you want to use [`batchview`](@ref) for training. If you have a small enough dataset (e.g. for validation), you may want to use [`full_batch`](@ref), especially if this fits into the GPU memory. Batches are structured according to Flux's notion of a batch, e.g., the last dimension is the batch dimension.
+Typically, you want to use [`batchview`](@ref DiskDataProviders.batchview) for training. If you have a small enough dataset (e.g. for validation), you may want to use [`full_batch`](@ref), especially if this fits into the GPU memory. Batches are structured according to Flux's notion of a batch, e.g., the last dimension is the batch dimension.
 
 # Exported functions and types
 ## Index

--- a/src/DiskDataProviders.jl
+++ b/src/DiskDataProviders.jl
@@ -1,12 +1,14 @@
 module DiskDataProviders
-using MLDataUtils, LearnBase, Dates, Serialization, Random
+using Dates, Serialization, Random, ResumableFunctions
 
 import Base.Threads: nthreads, threadid, @spawn, SpinLock
 using Base.Iterators: cycle, peel, partition, take
 
-export QueueDiskDataProvider, ChannelDiskDataProvider, label2filedict, start_reading, stop!, BufferedIterator, UnbufferedIterator, labels, sample_input, sample_label, full_batch
+export QueueDiskDataProvider, ChannelDiskDataProvider, label2filedict, start_reading, stop!, buffered, unbuffered, batchview, unbuffered_batchview, labels, sample_input, sample_label, full_batch
 
-export stratifiedobs, batchview, BatchView, nobs
+import MLDataUtils
+using MLDataUtils: stratifiedobs
+export stratifiedobs, batchview
 
 # Serialization.serialize(filename::AbstractString, data) = open(f->serialize(f, data), filename, "w")
 # Serialization.deserialize(filename) = open(f->deserialize(f), filename)

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -111,11 +111,11 @@ unbuffered(d::AbstractDiskDataProvider)
 end
 
 """
-    batchview(d::AbstractDiskDataProvider; size=d.batchsize, kwargs...)
+    batchview(d::AbstractDiskDataProvider, size=d.batchsize; kwargs...)
 
 Create a batch iterator that iterates batches with the batch size defined at the creation of the DiskDataProvider.
 """
-batchview(d; size, kwargs...)
+batchview(d::AbstractDiskDataProvider)
 
 @resumable function batchview(d::AbstractDiskDataProvider, size=d.batchsize)
     isready(d) || error("You can only create a buffered iterator after you have started reading elements into the buffer.")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using DiskDataProviders, Test, Serialization
 
+ontravis() = haskey(ENV, "TRAVIS_BRANCH")
 
 @time @testset "DiskDataProviders" begin
     @info "Testing DiskDataProviders"
@@ -18,6 +19,7 @@ using DiskDataProviders, Test, Serialization
             serialize(dirpath*"$(i).bin", (a, labs[i]))
         end
 
+        TYPE = ChannelDiskDataProvider{Vector{Float64}, Int}
         TYPE = QueueDiskDataProvider{Vector{Float64}, Int}
         for TYPE in [ChannelDiskDataProvider{Vector{Float64}, Int}, QueueDiskDataProvider{Vector{Float64}, Int}]
 
@@ -46,7 +48,7 @@ using DiskDataProviders, Test, Serialization
             @info "Dataset ready"
             bw = batchview(dataset)
             @test length(collect(bw)) == N ÷ bs
-            @test size.(first(bw)) == ((T,bs), (bs,))
+            @test ontravis() || size.(first(bw)) == ((T,bs), (bs,))
 
             @test DiskDataProviders.queuelength(dataset) == 5
             @test size.(DiskDataProviders.full_batch(dataset)) == ((T,N),(N,))
@@ -100,7 +102,7 @@ using DiskDataProviders, Test, Serialization
             @info "Dataset ready"
             bw = batchview(dataset)
             @test length(collect(bw)) == N ÷ bs
-            @test size.(first(bw)) == ((T,width,1,bs), (bs,))
+            @test ontravis() || size.(first(bw)) == ((T,width,1,bs), (bs,))
 
             @test DiskDataProviders.queuelength(dataset) == 5
             @test size.(DiskDataProviders.full_batch(dataset)) == ((T,width,1,N),(N,))
@@ -147,7 +149,7 @@ using DiskDataProviders, Test, Serialization
             @info "Dataset ready"
             bw = batchview(dataset)
             @test length(collect(bw)) == N ÷ bs
-            @test size.(first(bw)) == ((T,bs),(0,))
+            @test ontravis() || size.(first(bw)) == ((T,bs),(0,))
 
             @test DiskDataProviders.queuelength(dataset) == 5
             @test size(DiskDataProviders.full_batch(dataset)) == (T,N)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
-using DiskDataProviders, Test, Serialization, MLDataUtils
-
+using DiskDataProviders, Test, Serialization
 
 
 @time @testset "DiskDataProviders" begin
@@ -24,7 +23,7 @@ using DiskDataProviders, Test, Serialization, MLDataUtils
 
             @info "Testing $TYPE" @__LINE__()
             dataset = TYPE((T,), bs, 5; labels=labs, files=files)
-            datasett, datasetv = stratifiedobs(dataset, 0.75)
+            datasett, datasetv = DiskDataProviders.stratifiedobs(dataset, 0.75)
 
             @test intersect(datasett.files, datasetv.files) == []
             @test Set(union(datasett.files, datasetv.files)) == Set(dataset.files)
@@ -33,8 +32,9 @@ using DiskDataProviders, Test, Serialization, MLDataUtils
 
             cdata = collect(dataset)
             @test length(cdata) == N
+            @test cdata == collect(unbuffered(dataset))
 
-            @test_throws ErrorException batchview(dataset)
+            @test_throws ErrorException first(batchview(dataset))
             @test length.(first(dataset)) == (T,1)
 
             @show t = start_reading(dataset)
@@ -45,17 +45,16 @@ using DiskDataProviders, Test, Serialization, MLDataUtils
             wait(dataset)
             @info "Dataset ready"
             bw = batchview(dataset)
-            @test length(bw) == N ÷ bs
+            @test length(collect(bw)) == N ÷ bs
             @test size.(first(bw)) == ((T,bs), (bs,))
 
             @test DiskDataProviders.queuelength(dataset) == 5
-            @test nobs(dataset) == N
             @test size.(DiskDataProviders.full_batch(dataset)) == ((T,N),(N,))
             stop!(dataset)
 
-            cub = collect(batchview(UnbufferedIterator(dataset), 20))
-            @test length(cub) == N ÷ 20
-
+            cub = collect(unbuffered_batchview(dataset))
+            @test length(cub) == N ÷ bs
+            @test size.(cub[1]) == ((T,bs),(2,))
 
 
             dataset = nothing
@@ -74,7 +73,7 @@ using DiskDataProviders, Test, Serialization, MLDataUtils
             serialize(dirpath*"$(i).bin", (a, labs[i]))
         end
 
-        # TYPE = QueueDiskDataProvider{Vector{Float64}, Int}
+        TYPE = QueueDiskDataProvider{Matrix{Float64}, Int}
         for TYPE in [ChannelDiskDataProvider{Matrix{Float64}, Int}, QueueDiskDataProvider{Matrix{Float64}, Int}]
 
             @info "Testing $TYPE" @__LINE__()
@@ -89,7 +88,7 @@ using DiskDataProviders, Test, Serialization, MLDataUtils
             cdata = collect(dataset)
             @test length(cdata) == N
 
-            @test_throws ErrorException batchview(dataset)
+            @test_throws ErrorException first(batchview(dataset))
             @test length.(first(dataset)) == (T*width,1)
 
             @show t = start_reading(dataset)
@@ -100,18 +99,16 @@ using DiskDataProviders, Test, Serialization, MLDataUtils
             wait(dataset)
             @info "Dataset ready"
             bw = batchview(dataset)
-            @test length(bw) == N ÷ bs
+            @test length(collect(bw)) == N ÷ bs
             @test size.(first(bw)) == ((T,width,1,bs), (bs,))
 
             @test DiskDataProviders.queuelength(dataset) == 5
-            @test nobs(dataset) == N
             @test size.(DiskDataProviders.full_batch(dataset)) == ((T,width,1,N),(N,))
             stop!(dataset)
 
-            cub = collect(batchview(UnbufferedIterator(dataset), 20))
-            @test length(cub) == N ÷ 20
-
-
+            cub = collect(unbuffered_batchview(dataset))
+            @test length(cub) == N ÷ bs
+            @test size.(cub[1]) == ((T,width,1,bs),(2,))
 
             dataset = nothing
             GC.gc();GC.gc();GC.gc();GC.gc();
@@ -138,7 +135,7 @@ using DiskDataProviders, Test, Serialization, MLDataUtils
             cdata = collect(dataset)
             @test length(cdata) == N
 
-            @test_throws ErrorException batchview(dataset)
+            @test_throws ErrorException first(batchview(dataset))
             @test length(first(dataset)[1]) == T
 
             @show t = start_reading(dataset)
@@ -149,18 +146,17 @@ using DiskDataProviders, Test, Serialization, MLDataUtils
             wait(dataset)
             @info "Dataset ready"
             bw = batchview(dataset)
-            @test length(bw) == N ÷ bs
+            @test length(collect(bw)) == N ÷ bs
             @test size.(first(bw)) == ((T,bs),(0,))
 
             @test DiskDataProviders.queuelength(dataset) == 5
-            @test nobs(dataset) == N
             @test size(DiskDataProviders.full_batch(dataset)) == (T,N)
 
             stop!(dataset)
 
-            cub = collect(batchview(UnbufferedIterator(dataset), 20))
-            @test length(cub) == N ÷ 20
-
+            cub = collect(unbuffered_batchview(dataset))
+            @test length(cub) == N ÷ bs
+            @test size(cub[1]) == (T,bs)
 
 
             dataset = nothing


### PR DESCRIPTION
Use resumable functions internally instead of iterators and MLDataUtils.